### PR TITLE
Remove yocto kernel cache

### DIFF
--- a/recipes-bsp/linux/linux-raspberrypi.inc
+++ b/recipes-bsp/linux/linux-raspberrypi.inc
@@ -13,7 +13,6 @@ KMETA = "kernel-meta"
 
 SRC_URI = "\
 	https://github.com/raspberrypi/linux/archive/${SRCREV}.tar.gz \
-	git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.4;destsuffix=${KMETA} \
 	file://rpi_defconfig \
 	file://${OPENVISION_BASE}/meta-openvision/recipes-linux/kernel-patches/kernel-add-support-for-gcc${VISIONGCCVERSION}.patch \
 	"


### PR DESCRIPTION
Yocto kernel cache contains scripts / mods / patches to the mainline linux kernel for the yocto linux reference kernel.