### PR TITLE
Update sdcard_image-rpi.bbclass

### DIFF
--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -104,14 +104,14 @@ IMAGE_CMD_rpi-sdimg () {
 		# Copy board device trees to root folder
 		for dtbf in ${@split_overlays(d, True)}; do
 			dtb=`basename $dtbf`
-			mcopy -v -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-$dtb ::$dtb || bbfatal "mcopy cannot copy ${DEPLOY_DIR_IMAGE}/$dtb into boot.img"
+			mcopy -v -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/$dtb ::$dtb || bbfatal "mcopy cannot copy ${DEPLOY_DIR_IMAGE}/$dtb into boot.img"
 		done
 
 		# Copy device tree overlays to dedicated folder
 		mmd -i ${WORKDIR}/boot.img overlays
 		for dtbf in ${@split_overlays(d, False)}; do
 			dtb=`basename $dtbf`
-			mcopy -v -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-$dtb ::overlays/$dtb || bbfatal "mcopy cannot copy ${DEPLOY_DIR_IMAGE}/$dtb into boot.img"
+			mcopy -v -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/$dtb ::overlays/$dtb || bbfatal "mcopy cannot copy ${DEPLOY_DIR_IMAGE}/$dtb into boot.img"
 		done
 	fi
 


### PR DESCRIPTION
kernel-devicetree.bbclass does not respect kernel image type
see also http://git.yoctoproject.org/cgit/cgit.cgi/meta-raspberrypi/commit/classes/sdcard_image-rpi.bbclass?id=4826d225807850f082d99ba42019023e54215b84
Should fix https://forum.openvision.tech/viewtopic.php?p=11364#p11364