### PR TITLE
Support old rpi (armv6) with webm/libvpx version 1.6.0

### DIFF
--- a/conf/machine/raspberrypi.conf
+++ b/conf/machine/raspberrypi.conf
@@ -28,3 +28,5 @@ RPI_KERNEL_DEVICETREE_OVERLAYS += "\
 DVBMEDIASINK_CONFIG = "--with-wmv --with-pcm --with-eac3 --with-dtsdownmix"
 
 MACHINE_FEATURES += "nolcd RCA"
+
+PREFERRED_VERSION_libvpx = "1.6.0"

--- a/recipes-multimedia/webm/libvpx_1.6.0.bb
+++ b/recipes-multimedia/webm/libvpx_1.6.0.bb
@@ -1,0 +1,50 @@
+SUMMARY = "VPX multi-format codec"
+DESCRIPTION = "The BSD-licensed libvpx reference implementation provides en- and decoders for VP8 and VP9 bitstreams."
+HOMEPAGE = "http://www.webmproject.org/code/"
+BUGTRACKER = "http://code.google.com/p/webm/issues/list"
+SECTION = "libs/multimedia"
+LICENSE = "BSD-3-Clause"
+
+LIC_FILES_CHKSUM = "file://LICENSE;md5=d5b04755015be901744a78cc30d390d4"
+
+SRCREV = "042572177b5c58404836fce3fc221fd077dcd896"
+SRC_URI += "git://chromium.googlesource.com/webm/libvpx;protocol=https \
+            file://libvpx-configure-support-blank-prefix.patch \
+           "
+
+S = "${WORKDIR}/git"
+
+# ffmpeg links with this and fails
+# sysroots/armv4t-oe-linux-gnueabi/usr/lib/libvpx.a(vpx_encoder.c.o)(.text+0xc4): unresolvable R_ARM_THM_CALL relocation against symbol `memcpy@@GLIBC_2.4'
+ARM_INSTRUCTION_SET = "arm"
+
+CFLAGS += "-fPIC"
+
+export CC
+export LD = "${CC}"
+
+VPXTARGET_armv5te = "armv5te-linux-gcc"
+VPXTARGET_armv6 = "armv6-linux-gcc"
+VPXTARGET_armv7a = "armv7-linux-gcc"
+VPXTARGET ?= "generic-gnu"
+
+CONFIGUREOPTS = " \
+    --target=${VPXTARGET} \
+    --enable-vp9 \
+    --enable-libs \
+    --disable-install-docs \
+    --disable-static \
+    --enable-shared \
+    --prefix=${prefix} \
+    --libdir=${libdir} \
+    --size-limit=16384x16384 \
+"
+
+do_configure() {
+    ${S}/configure ${CONFIGUREOPTS}
+}
+
+do_install() {
+    oe_runmake install DESTDIR=${D}
+    chown -R root:root ${D}
+}


### PR DESCRIPTION
I hope this is the only exception for libraries.

Now I know why you left rpi in ov7.x :)

Will that preferred version only be applied to rpi while in it's conf file?
Should that be maintained in preferred-provider-version of the distro?